### PR TITLE
Upgrade to .NET 6

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/Camellia/Camellia.csproj
+++ b/Camellia/Camellia.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dangl.Calculator" Version="1.4.0" />
-    <PackageReference Include="Discord.Net" Version="2.4.0" />
+    <PackageReference Include="Dangl.Calculator" Version="2.0.0" />
+    <PackageReference Include="Discord.Net" Version="3.9.0" />
   </ItemGroup>
 
 </Project>

--- a/Camellia/Modules/Communication.cs
+++ b/Camellia/Modules/Communication.cs
@@ -19,7 +19,8 @@ namespace Camellia.Modules
                     "**XML [text]:** Check if an XML is valid or not\n" +
                     "**Calc [operation]:** Evaluate a mathematical expression\n" +
                     "**Bytes [number of bytes]:** Generates a string of cryptographic random bytes\n" +
-                    "**Duration [date 1] [date 2]:** Display the duration between 2 dates",
+                    "**Duration [date 1] [date 2]:** Display the duration between 2 dates\n" +
+                    "**Invite** Get the invite link of the bot",
                 Color = Color.Blue,
                 Footer = new EmbedFooterBuilder
                 {
@@ -31,7 +32,7 @@ namespace Camellia.Modules
         [Command("Invite")]
         public async Task InviteAsync()
         {
-            await ReplyAsync("https://discord.com/api/oauth2/authorize?client_id=867196397361954837&scope=bot");
+            await ReplyAsync($"https://discord.com/api/oauth2/authorize?client_id={Context.Client.CurrentUser.Id}&scope=bot");
         }
     }
 }

--- a/Camellia/Program.cs
+++ b/Camellia/Program.cs
@@ -20,7 +20,8 @@ namespace Camellia
 
         private readonly DiscordSocketClient _client = new(new DiscordSocketConfig
         {
-            LogLevel = LogSeverity.Verbose
+            LogLevel = LogSeverity.Verbose,
+            GatewayIntents = GatewayIntents.AllUnprivileged | GatewayIntents.MessageContent
         });
         private readonly CommandService _commands = new();
 


### PR DESCRIPTION
Upgrade Camellia to .NET 6 (chose for 6 since it's LTS and this bot is not updated much) since it was still on end of life .NET 5.

Also added the invite command to help and replaced the hardcoded ID.