### PR TITLE
Update to .NET 8

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/Camellia/Camellia.csproj
+++ b/Camellia/Camellia.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dangl.Calculator" Version="2.0.0" />
-    <PackageReference Include="Discord.Net" Version="3.9.0" />
+    <PackageReference Include="Dangl.Calculator" Version="2.2.0" />
+    <PackageReference Include="Discord.Net" Version="3.16.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
With the release of .NET 9, .NET 6 is now end-of-life. This pull request updates the project to the newest .NET 8 LTS.

See you in 2 years for .NET 10.