### PR TITLE
Add hex dump command

### DIFF
--- a/Camellia/Camellia.csproj
+++ b/Camellia/Camellia.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Dangl.Calculator" Version="2.2.0" />
-    <PackageReference Include="Discord.Net" Version="3.16.0" />
+    <PackageReference Include="Discord.Net" Version="3.18.0" />
   </ItemGroup>
 
 </Project>

--- a/Camellia/Modules/Communication.cs
+++ b/Camellia/Modules/Communication.cs
@@ -20,6 +20,7 @@ namespace Camellia.Modules
                     "**Calc [operation]:** Evaluate a mathematical expression\n" +
                     "**Bytes [number of bytes]:** Generates a string of cryptographic random bytes\n" +
                     "**Duration [date 1] [date 2]:** Display the duration between 2 dates\n" +
+                    "**Hexdump:** Displays a hex dump of the contents of the specified file\n" +
                     "**Invite** Get the invite link of the bot",
                 Color = Color.Blue,
                 Footer = new EmbedFooterBuilder

--- a/Camellia/Utils.cs
+++ b/Camellia/Utils.cs
@@ -1,0 +1,35 @@
+﻿using System.Linq;
+using System.Text;
+
+namespace Camellia
+{
+    public static class Utils
+    {
+        public static string ToHexdump(byte[] data, int width = 16)
+        {
+            var builder = new StringBuilder();
+
+            for (int i = 0; i < data.Length; i += width)
+            {
+                var slice = data.Skip(i).Take(width).ToArray();
+
+                // Hex dump
+                builder.Append(string.Join(" ", slice.Select(x => x.ToString("X2"))).PadRight((width * 3) + 1));
+
+                // ASCII dump
+                builder.Append(string.Join("", slice.Select(ToPrintable)));
+
+                builder.AppendLine();
+            }
+
+            return builder.ToString();
+        }
+
+        public static string ToPrintable(byte octet)
+        {
+            // Whether the character is not printable
+            if (octet < ' ' || octet > '~') return ".";
+            return ((char)octet).ToString();
+        }
+    }
+}


### PR DESCRIPTION
Adds a command to see the hex dump of an uploaded file

<img width="654" height="373" alt="image" src="https://github.com/user-attachments/assets/56786a68-4574-4fb4-8e23-cbf3a3f8db39" />

Works either by attaching a file to the message or by replying to a message with an attached file.